### PR TITLE
Expose version parsing function

### DIFF
--- a/src/diraccfg/__init__.py
+++ b/src/diraccfg/__init__.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
 __all__ = [
-    'CFG',
+    "CFG",
+    "parseVersion",
 ]
 
 from .cfg import CFG
+from .versions import parseVersion

--- a/src/diraccfg/versions.py
+++ b/src/diraccfg/versions.py
@@ -7,6 +7,11 @@ import re
 
 def parseVersion(versionString):
   """Parse a DIRAC-style version sting
+
+  :param versionString: Version identifier to parse
+  :returns: `tuple` of 4 values (major, minor, patch, pre). All values will be
+            `int` except "pre" which is `None` for released versions.
+  :raises: ValueError if the versionString is invalid
   """
   match = re.match(
       r"^v(?P<major>\d+)r(?P<minor>\d+)(?:p(?P<patch>\d+))?(?:-pre(?P<pre>\d+))?$",

--- a/src/diraccfg/versions.py
+++ b/src/diraccfg/versions.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import re
+
+
+def parseVersion(versionString):
+  """Parse a DIRAC-style version sting
+  """
+  match = re.match(
+      r"^v(?P<major>\d+)r(?P<minor>\d+)(?:p(?P<patch>\d+))?(?:-pre(?P<pre>\d+))?$",
+      versionString,
+  )
+  if not match:
+    raise ValueError("%s is not a valid version" % versionString)
+
+  segments = match.groupdict()
+  for k, v in segments.items():
+    if k != "pre" and v is None:
+      segments[k] = 0
+    if v is not None:
+      segments[k] = int(v)
+
+  return (segments["major"], segments["minor"], segments["patch"], segments["pre"])

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import pytest
+
+import diraccfg
+
+
+@pytest.mark.parametrize(
+    "string,expected",
+    [
+        ("v7r0p30", (7, 0, 30, None)),
+        ("v7r1", (7, 1, 0, None)),
+        ("v7r1-pre1", (7, 1, 0, 1)),
+        ("v7r1-pre9", (7, 1, 0, 9)),
+        ("v7r1p10", (7, 1, 10, None)),
+        ("v7r1p9", (7, 1, 9, None)),
+        ("v7r2-pre10", (7, 2, 0, 10)),
+        ("v7r2-pre9", (7, 2, 0, 9)),
+        ("v7r2p8-pre9", (7, 2, 8, 9)),
+
+        ("v10r0p30", (10, 0, 30, None)),
+        ("v10r1", (10, 1, 0, None)),
+        ("v10r1-pre1", (10, 1, 0, 1)),
+        ("v10r1-pre9", (10, 1, 0, 9)),
+        ("v10r1p10", (10, 1, 10, None)),
+        ("v10r1p9", (10, 1, 9, None)),
+        ("v10r2-pre10", (10, 2, 0, 10)),
+        ("v10r2-pre9", (10, 2, 0, 9)),
+        ("v10r2p8-pre9", (10, 2, 8, 9)),
+
+        ("v100r0p30", (100, 0, 30, None)),
+        ("v100r1", (100, 1, 0, None)),
+        ("v100r1-pre1", (100, 1, 0, 1)),
+        ("v100r1-pre9", (100, 1, 0, 9)),
+        ("v100r1p10", (100, 1, 10, None)),
+        ("v100r1p9", (100, 1, 9, None)),
+        ("v100r2-pre10", (100, 2, 0, 10)),
+        ("v100r2-pre9", (100, 2, 0, 9)),
+        ("v100r2p8-pre9", (100, 2, 8, 9)),
+    ],
+)
+def test_parseValid(string, expected):
+  assert expected == diraccfg.parseVersion(string)
+
+
+@pytest.mark.parametrize(
+    "string",
+    [
+        "v7r0p30-pre30-pre30",
+        "master",
+        "dev",
+        "integration",
+        "7r0p30",
+        "v7r2p30p2",
+        "1.0.0",
+        "v7p30",
+        "v7p30-pre2",
+        "v10p30",
+        "v10p30-pre2",
+        "v100p30",
+        "v100p30-pre2",
+    ],
+)
+def test_parseInvalid(string):
+  with pytest.raises(ValueError):
+    diraccfg.parseVersion(string)


### PR DESCRIPTION
As requested by @petricm, exposes the version parsing regex as:

```python
major, minor, pre, patch = diracCfg.parseVersion("v10r1p3")
assert major, minor, pre, patch == (10, 1, 3, None)

major, minor, pre, patch = diracCfg.parseVersion("v10r1")
assert major, minor, pre, patch == (10, 1, 0, None)

major, minor, pre, patch = diracCfg.parseVersion("v10r1-pre3")
assert major, minor, pre, patch == (10, 1, 0, 3)

```