### PR TITLE
Add sanity check to match opening and closing brackets

### DIFF
--- a/src/diraccfg/cfg.py
+++ b/src/diraccfg/cfg.py
@@ -922,6 +922,8 @@ class CFG(object):
     :type data: string
     :param data: Contents of the CFG
     :return: This CFG
+
+    :raise SyntaxError: in case the number of opening and closing brackets do not match
     """
     commentRE = re.compile(r"^\s*#")
     self.reset()
@@ -945,7 +947,10 @@ class CFG(object):
           currentlyParsedString = ""
           currentComment = ""
         elif line[index] == "}":
-          currentLevel = levelList.pop()
+          try:
+            currentLevel = levelList.pop()
+          except IndexError:
+            raise SyntaxError("The cfg file seems to close more section than it opens (i.e. to many '}' vs '{'")
         elif line[index] == "=":
           lFields = line.split("=")
           currentLevel.setOption(lFields[0].strip(), "=".join(lFields[1:]).strip(), currentComment)
@@ -960,6 +965,9 @@ class CFG(object):
           break
         else:
           currentlyParsedString += line[index]
+    # At this point, the levelList should be empty
+    if levelList:
+      raise SyntaxError("The cfg file seems to open more section than it closes (i.e. to many '{' vs '}'")
     return self
 
   @gCFGSynchro

--- a/src/diraccfg/cfg.py
+++ b/src/diraccfg/cfg.py
@@ -950,7 +950,7 @@ class CFG(object):
           try:
             currentLevel = levelList.pop()
           except IndexError:
-            raise SyntaxError("The cfg file seems to close more section than it opens (i.e. to many '}' vs '{'")
+            raise ValueError("The cfg file seems to close more sections than it opens (i.e. to many '}' vs '{'")
         elif line[index] == "=":
           lFields = line.split("=")
           currentLevel.setOption(lFields[0].strip(), "=".join(lFields[1:]).strip(), currentComment)
@@ -967,7 +967,7 @@ class CFG(object):
           currentlyParsedString += line[index]
     # At this point, the levelList should be empty
     if levelList:
-      raise SyntaxError("The cfg file seems to open more section than it closes (i.e. to many '{' vs '}'")
+      raise ValueError("The cfg file seems to open more sections than it closes (i.e. to many '{' vs '}'")
     return self
 
   @gCFGSynchro

--- a/tests/broken_close.cfg
+++ b/tests/broken_close.cfg
@@ -1,0 +1,20 @@
+# Broken because more opening brackets than closing
+DefaultModules = DIRAC
+Sources
+{
+  DIRAC = git://github.com/DIRACGrid/DIRAC.git
+}
+Releases
+{
+  integration
+  {
+    Modules = DIRAC, WebAppDIRAC, VMDIRAC
+    Externals = v6r6p8
+    DIRACOS = master
+  # Here is a missing }
+  v7r0-pre19
+  {
+    Modules = DIRAC, VMDIRAC:v2r4-pre2, RESTDIRAC:v0r5, COMDIRAC:v0r17, WebAppDIRAC:v4r0p7, OAuthDIRAC:v0r1-pre1
+    DIRACOS = master
+  }
+}

--- a/tests/broken_open.cfg
+++ b/tests/broken_open.cfg
@@ -1,0 +1,21 @@
+# That is a broken file, with more closing bracket than opening
+#
+DefaultModules = DIRAC
+Sources
+{
+  DIRAC = git://github.com/DIRACGrid/DIRAC.git
+}
+Releases
+{
+  integration
+  # here is a missing {
+    Modules = DIRAC, WebAppDIRAC, VMDIRAC
+    Externals = v6r6p8
+    DIRACOS = master
+  }
+  v7r0-pre19
+  {
+    Modules = DIRAC, VMDIRAC:v2r4-pre2, RESTDIRAC:v0r5, COMDIRAC:v0r17, WebAppDIRAC:v4r0p7, OAuthDIRAC:v0r1-pre1
+    DIRACOS = master
+  }
+}

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -18,10 +18,10 @@ def test_comment():
 
 
 def test_sanity():
-  with pytest.raises(SyntaxError) as excinfo:
+  with pytest.raises(ValueError) as excinfo:
     rels = CFG().loadFromFile(BROKEN_OPEN_CFG_FILE)
   assert 'close more section' in str(excinfo)
 
-  with pytest.raises(SyntaxError) as excinfo:
+  with pytest.raises(ValueError) as excinfo:
     rels = CFG().loadFromFile(BROKEN_CLOSE_CFG_FILE)
   assert 'open more section' in str(excinfo)

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -1,8 +1,10 @@
 import os
-
+import pytest
 from diraccfg.cfg import CFG
 
 EXAMPLE_CFG_FILE = os.path.join(os.path.dirname(__file__), 'releases.cfg')
+BROKEN_OPEN_CFG_FILE = os.path.join(os.path.dirname(__file__), 'broken_open.cfg')
+BROKEN_CLOSE_CFG_FILE = os.path.join(os.path.dirname(__file__), 'broken_close.cfg')
 
 
 def test_load():
@@ -13,3 +15,13 @@ def test_load():
 def test_comment():
   c = CFG().loadFromFile(EXAMPLE_CFG_FILE)
   c.getComment('Releases').strip() == 'Here is where the releases go:'
+
+
+def test_sanity():
+  with pytest.raises(SyntaxError) as excinfo:
+    rels = CFG().loadFromFile(BROKEN_OPEN_CFG_FILE)
+  assert 'close more section' in str(excinfo)
+
+  with pytest.raises(SyntaxError) as excinfo:
+    rels = CFG().loadFromFile(BROKEN_CLOSE_CFG_FILE)
+  assert 'open more section' in str(excinfo)


### PR DESCRIPTION
Up to now, if there were more opening than closing brackets, dirac would just happily continue, and give you very weird result (the net result being that your config is shifted by one depth). Here, I make it raise `SyntaxError` upon reading. And for consistency, I do the same if there are too many closing brackets (this would have triggered an `IndexError` before)