### PR TITLE
Add type hints and mypy CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
       run: |
         . "${CONDA}/bin/activate" test-env
         pytest
+    - name: Run mypy
+      run: |
+        . "${CONDA}/bin/activate" test-env
+        mypy
     - name: Run pylint
       run: |
         . "${CONDA}/bin/activate" test-env

--- a/.github/workflows/prepare_environment.sh
+++ b/.github/workflows/prepare_environment.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 PYTHON_VERSION=$1
 
-conda create --quiet -c conda-forge -c free -n test-env \
+conda create --quiet -c conda-forge -n test-env \
     python="$PYTHON_VERSION" \
     "pytest>=4.6" pylint pytest-cov pycodestyle \
-    setuptools setuptools_scm wheel
+    setuptools setuptools_scm wheel mypy
 source "${CONDA}/bin/activate" test-env
 pip install ".[testing]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,10 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 120
 target-version = ['py39']
+
+[tool.mypy]
+strict = true
+files = 'src/diraccfg'
+
+[tool.pylint."messages control"]
+disable = ["unsubscriptable-object"]

--- a/src/diraccfg/__main__.py
+++ b/src/diraccfg/__main__.py
@@ -1,13 +1,16 @@
+from __future__ import annotations
+
 import argparse
 import json
 import os
 import sys
+from typing import NoReturn
 
 from .cfg import CFG
 from .versions import parseVersion
 
 
-def parseArgs():
+def parseArgs() -> NoReturn:
     parser = argparse.ArgumentParser(description="Parser for DIRAC cfg files")
     subparsers = parser.add_subparsers(help="Actions to run with the ")
 
@@ -27,7 +30,7 @@ def parseArgs():
     sys.exit(0)
 
 
-def dumpAsJson(cfgFilename):
+def dumpAsJson(cfgFilename: str) -> None:
     if not os.path.isfile(cfgFilename):
         sys.stderr.write(f"ERROR: {cfgFilename} does not exist\n")
         sys.exit(1)
@@ -35,7 +38,7 @@ def dumpAsJson(cfgFilename):
     print(json.dumps(res.getAsDict()))
 
 
-def sortVersions(allow_pre_releases=False):
+def sortVersions(allow_pre_releases: bool = False) -> None:
     try:
         objs = json.loads(sys.stdin.read())
     except getattr(json, "JSONDecodeError", ValueError):
@@ -56,7 +59,7 @@ def sortVersions(allow_pre_releases=False):
                 continue
             parsedVersions[obj] = (major, minor, patch, pre)
 
-    print(json.dumps(sorted(parsedVersions, key=parsedVersions.get, reverse=True)))
+    print(json.dumps(sorted(parsedVersions, key=parsedVersions.__getitem__, reverse=True)))
 
 
 if __name__ == "__main__":

--- a/src/diraccfg/versions.py
+++ b/src/diraccfg/versions.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import re
 
 
-def parseVersion(versionString):
+def parseVersion(versionString: str) -> tuple[int, int, int, int | None]:
     """Parse a DIRAC-style version sting
 
     :param versionString: Version identifier to parse
@@ -16,11 +18,9 @@ def parseVersion(versionString):
     if not match:
         raise ValueError(f"{versionString} is not a valid version")
 
-    segments = match.groupdict()
-    for k, v in segments.items():
-        if k != "pre" and v is None:
-            segments[k] = 0
-        if v is not None:
-            segments[k] = int(v)
-
-    return (segments["major"], segments["minor"], segments["patch"], segments["pre"])
+    return (
+        int(match.group("major")),
+        int(match.group("minor")),
+        int(match.group("patch") or 0),
+        None if match.group("pre") is None else int(match.group("pre")),
+    )

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -338,7 +338,7 @@ def test_comments():
 
     assert a.getComment("a") == ""
     assert a.setComment("a", "some comment") is True
-    a.getComment("a") == "some comment"
+    assert a.getComment("a") == "some comment"
 
     assert "missing" not in a
     assert a.setComment("missing", "some comment") is False
@@ -352,7 +352,7 @@ def test_comments_nested():
     a = CFG().loadFromDict({"a": "1", "b": "2", "c": {"d": "3", "e": "4"}})
     assert a.getComment("/c/d") == ""
     assert a.setComment("/c/d", "some other comment") is True
-    a.getComment("/c/d") == "some other comment"
+    assert a.getComment("/c/d") == "some other comment"
 
 
 def test_getitem():
@@ -392,7 +392,7 @@ def test_setOption():
     assert a.getOption("/c/x") == "hello world"
 
     assert a.getOption("/missing/z") is None
-    assert a.setOption("/missing/z", "invalid")["OK"] == False
+    assert a.setOption("/missing/z", "invalid")["OK"] is False
     assert a.getOption("/missing/z") is None
 
     with pytest.raises(KeyError, match=r"doesn't seem to be a section"):
@@ -708,9 +708,9 @@ def test_createNewSection():
     with pytest.raises(KeyError, match="Entry a doesn't seem to"):
         a.createNewSection("/a/new9")
 
-    assert a.createNewSection("/new2/new9/new10")["OK"] == False
-    assert a.createNewSection("new3/new4")["OK"] == False
-    assert a.createNewSection("/new3/new4")["OK"] == False
+    assert a.createNewSection("/new2/new9/new10")["OK"] is False
+    assert a.createNewSection("new3/new4")["OK"] is False
+    assert a.createNewSection("/new3/new4")["OK"] is False
 
 
 def test_writeToFile(tmp_path):


### PR DESCRIPTION
This adds pretty much full typing to diraccfg and makes it so that `mypy --strict` passes. It uses a few more `cast`s than I'd like but the interface makes it hard not to without redesigning it a little.